### PR TITLE
Compatibility with gcc 9 and icu 61+

### DIFF
--- a/src/api/game/load_order_handler.h
+++ b/src/api/game/load_order_handler.h
@@ -27,6 +27,7 @@
 
 #include <filesystem>
 #include <list>
+#include <vector>
 #include <string>
 #include <unordered_set>
 

--- a/src/api/helpers/text.cpp
+++ b/src/api/helpers/text.cpp
@@ -35,6 +35,7 @@
 #endif
 
 using std::regex;
+using icu::UnicodeString;
 
 namespace loot {
 /* The string below matches timestamps that use forwardslashes for date

--- a/src/api/helpers/text.cpp
+++ b/src/api/helpers/text.cpp
@@ -32,10 +32,10 @@
 #else
 #include <unicode/uchar.h>
 #include <unicode/unistr.h>
+using icu::UnicodeString;
 #endif
 
 using std::regex;
-using icu::UnicodeString;
 
 namespace loot {
 /* The string below matches timestamps that use forwardslashes for date


### PR DESCRIPTION
Fixes https://github.com/loot/libloot/issues/61

Building with gcc 8 is fine but gcc 9 needs a vector include.

ICU 61 and higher (tested with 64.2) needs a `using` added - http://site.icu-project.org/download/61#TOC-Migration-Issues
